### PR TITLE
[ppp] Explicitly depend on pkgconfig(libcrypt). JB#54931

### DIFF
--- a/rpm/ppp.spec
+++ b/rpm/ppp.spec
@@ -10,8 +10,9 @@ Patch1:     0002-Revert-pppd-Fix-setting-IPv6-peer-address-212.patch
 Requires:   openssl-libs
 BuildRequires:  coreutils
 BuildRequires:  sed
-BuildRequires:  openssl-devel
-BuildRequires:  libpcap-devel
+BuildRequires:  pkgconfig(openssl)
+BuildRequires:  pkgconfig(libpcap)
+BuildRequires:  pkgconfig(libcrypt)
 
 %description
 PPP point-to-point tunnelling daemon.


### PR DESCRIPTION
ppp depdends on pkconfig(libcrypt) for the crypt import but it was
not included. This fails when pkconfig(libcrypt) is not bundled in the glib-devel package.
Also convert -devel requires to use pkgconfig.